### PR TITLE
Persist bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 node_modules/
 **/mongo-c-driver-*
 **/bin/*
+!*bin/keep
 .vscode/
 **/lib/*
 !*lib/keep
 **/uploads/*
 !*uploads/keep
+


### PR DESCRIPTION
So that running the initial `make all` has a directory for the executable.